### PR TITLE
docs: add germline panel to reference exclusions section

### DIFF
--- a/docs/details.md
+++ b/docs/details.md
@@ -152,7 +152,7 @@ Exclusions fall into three tiers by ownership:
 
 **Reporting-level** — intentional downstream exclusions:
 
-- Germline variants restricted to transcript regions of the [PMCC germline predisposition panel](https://github.com/umccr/gene_panels/tree/main/germline_panel) (~77 genes) — variants outside these regions are not passed to CPSR ([Germline Small Variants → Prepare](#germline-small-variants))
+- Germline variants outside transcript regions of the [PMCC germline predisposition panel](https://github.com/umccr/gene_panels/tree/main/germline_panel) (~77 genes) are excluded and not passed to CPSR ([Germline Small Variants → Prepare](#germline-small-variants))
 - Restricted virus taxonomy via `virus_reporting_db` and `virus_taxonomy_db` ([conf/refdata.config#L86](conf/refdata.config#L86))
 
 In detail:

--- a/docs/details.md
+++ b/docs/details.md
@@ -152,6 +152,7 @@ Exclusions fall into three tiers by ownership:
 
 **Reporting-level** — intentional downstream exclusions:
 
+- Germline variants restricted to transcript regions of the [PMCC germline predisposition panel](https://github.com/umccr/gene_panels/tree/main/germline_panel) (~77 genes) — variants outside these regions are not passed to CPSR ([Germline Small Variants → Prepare](#germline-small-variants))
 - Restricted virus taxonomy via `virus_reporting_db` and `virus_taxonomy_db` ([conf/refdata.config#L86](conf/refdata.config#L86))
 
 In detail:


### PR DESCRIPTION
The PMCC germline predisposition panel (~77 genes) is a reporting-level exclusion — variants outside these regions are silently dropped before CPSR. It belongs in the Reference Exclusions and Blocklists section alongside the virus taxonomy and caller-level blocklists.