### PR TITLE
sash: skip VCF2MAF when PCGR skipped for high-variant-count samples (#52)

### DIFF
--- a/modules/local/bolt/smlv_somatic/report/main.nf
+++ b/modules/local/bolt/smlv_somatic/report/main.nf
@@ -19,9 +19,9 @@ process BOLT_SMLV_SOMATIC_REPORT {
     tuple val(meta), path("output/*.bcftools_stats.txt")          , emit: bcftools_stats
     tuple val(meta), path("output/*.variant_counts_type.yaml")    , emit: counts_type
     tuple val(meta), path("output/*.variant_counts_process.json") , emit: counts_process
-    tuple val(meta), path("output/pcgr/*.pcgr.grch38.pass.vcf.gz"), emit: pcgr_pass_vcf
-    path 'output/pcgr/'                                           , emit: pcgr_dir
-    path "output/*.pcgr.grch38.html"                              , emit: pcgr_report
+    tuple val(meta), path("output/pcgr/*.pcgr.grch38.pass.vcf.gz"), emit: pcgr_pass_vcf, optional: true
+    path 'output/pcgr/'                                           , emit: pcgr_dir    , optional: true
+    path "output/*.pcgr.grch38.html"                              , emit: pcgr_report , optional: true
     path 'versions.yml'                                           , emit: versions
 
     when:

--- a/workflows/sash.nf
+++ b/workflows/sash.nf
@@ -361,6 +361,7 @@ workflow SASH {
     //
 
     // channel: [ meta_vcf2maf, report_pcgr_pass_vcf ]
+    // Filter handles the case where PCGR was skipped (>450k variants) and pcgr_pass_vcf was not emitted
     ch_smlv_somatic_report_pcgr_pass_vcf_out = WorkflowSash.restoreMeta(BOLT_SMLV_SOMATIC_REPORT.out.pcgr_pass_vcf, ch_inputs)
         .map { meta, vcf ->
             def meta_vcf2maf = [
@@ -371,6 +372,7 @@ workflow SASH {
             ]
             return [meta_vcf2maf, vcf]
         }
+        .filter { _meta, vcf -> vcf }
 
     VCF2MAF(
         ch_smlv_somatic_report_pcgr_pass_vcf_out,


### PR DESCRIPTION
## Summary

Part of sash **0.7.1** (bolt 0.3.1 → 0.3.2).

- When bolt's PASS VCF exceeds 450k variants, `select_pcgr_variants` raises `RuntimeError` and PCGR is skipped (bolt-side fix: umccr/bolt#32, merged into `release/0.3.0`/tag `v0.3.2`).
- This marks `pcgr_pass_vcf`, `pcgr_dir`, and `pcgr_report` as `optional: true` on `BOLT_SMLV_SOMATIC_REPORT` so the process exits 0 and non-PCGR outputs (stats, AFs, counts) still publish for gpgr.
- Filters the `VCF2MAF` input channel to skip samples where `pcgr_pass_vcf` was not emitted.

Related:
- umccr/bolt#32 (merged, the underlying PCGR-skip fix)
- umccr/bolt#36 (single-chunk `bcftools merge` guard, bolt #26)

Closes #52.

## Test plan
- [x] `nextflow config .` — parses cleanly
- [x] `nextflow run . --help` — forces full DSL2 compilation of changed files, no syntax errors
- [x] No `nf-test` exists for `BOLT_SMLV_SOMATIC_REPORT` or this part of `workflows/sash.nf` (known gap, noted in CHANGELOG) — not run against real cloud data as part of this PR