### PR TITLE
docs: testing-validation SOP, release-validation template, and test samplesheets

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-validation.md
+++ b/.github/ISSUE_TEMPLATE/release-validation.md
@@ -1,0 +1,40 @@
+---
+name: Release validation
+about: Pre-merge validation checklist for a sash release or PR stack
+title: "Release validation — sash <version>"
+labels: validation
+---
+
+See [`docs/testing-validation.md`](../../docs/testing-validation.md) for the full procedure.
+
+## Scope
+
+PRs under test: #\_\_\_
+
+## Test samples
+
+| Sample                               | Mode      | S3 input                                                                                                                                         | Purpose                      |
+| ------------------------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------- |
+| SEQC-II SBJ00480 (L2300943/L2300950) | DRAGEN+OA | `s3://test-data-503977275616-ap-southeast-2/testdata/analysis/production/{dragen-wgts-dna/4.4.6,oncoanalyser-wgts-dna/2.2.0}/SEQC-II/`           | regression vs 0.6.4 baseline |
+| L2600284/L2600285                    | OA-only   | `s3://pipeline-prod-cache-503977275616-ap-southeast-2/byob-icav2/production/analysis/oncoanalyser-wgts-dna/20260716eec549b2/L2600284__L2600285/` | OA-only e2e (real v2.2.0)    |
+| synthetic 550k                       | PCGR-skip | see `docs/testing-validation.md`                                                                                                                 | >450k skip smoke             |
+
+Samplesheets: [`assets/test/`](../../assets/test).
+
+## Procedure
+
+- Standard / OA-only run: `docs/testing-validation.md`
+- Release comparison: Sash Regression Service (`umccr/service-sash-regression`, case SEQC-II-medium)
+- NATA: `umccr/accreditation/wgs-variant-monitoring-workflow/docs/`
+
+## Results
+
+| PR  | Sample | Run ID | Result | Concordance / notes |
+| --- | ------ | ------ | ------ | ------------------- |
+|     |        |        |        |                     |
+
+## Sign-off
+
+- [ ] somatic PASS concordance ≥ 81.2% vs baseline
+- [ ] PURPLE purity/ploidy identical to baseline
+- [ ] all cancer reports render

--- a/assets/test/samplesheet_dragen_oa_seqcii.csv
+++ b/assets/test/samplesheet_dragen_oa_seqcii.csv
@@ -1,0 +1,4 @@
+filepath,filetype,id,sample_name,subject_name
+s3://test-data-503977275616-ap-southeast-2/testdata/analysis/production/dragen-wgts-dna/4.4.6/SEQC-II/20260330a606412c/L2300943__L2300950__hg38__linear__dragen_wgts_dna_somatic_variant_calling/,dragen_somatic_dir,L2300943_L2300950,L2300943,SBJ00480
+s3://test-data-503977275616-ap-southeast-2/testdata/analysis/production/dragen-wgts-dna/4.4.6/SEQC-II/20260330a606412c/L2300950__hg38__graph__dragen_wgts_dna_germline_variant_calling/,dragen_germline_dir,L2300943_L2300950,L2300950,SBJ00480
+s3://test-data-503977275616-ap-southeast-2/testdata/analysis/production/oncoanalyser-wgts-dna/2.2.0/SEQC-II/20260401d6eff920/L2300943__L2300950/,oncoanalyser_dir,L2300943_L2300950,L2300943,SBJ00480

--- a/assets/test/samplesheet_oa_only_l2600284.csv
+++ b/assets/test/samplesheet_oa_only_l2600284.csv
@@ -1,0 +1,2 @@
+id,subject_name,sample_name,filetype,filepath,tumor_id,normal_id
+L2600284_L2600285,L2600284__L2600285,L2600284,oncoanalyser_dir,s3://pipeline-prod-cache-503977275616-ap-southeast-2/byob-icav2/production/analysis/oncoanalyser-wgts-dna/20260716eec549b2/L2600284__L2600285/,L2600284,L2600285

--- a/assets/test/samplesheet_oa_only_seqcii.csv
+++ b/assets/test/samplesheet_oa_only_seqcii.csv
@@ -1,0 +1,2 @@
+id,subject_name,sample_name,filetype,filepath,tumor_id,normal_id
+SEQCII_L2300943,SBJ00480,L2300943,oncoanalyser_dir,s3://test-data-503977275616-ap-southeast-2/testdata/analysis/production/oncoanalyser-wgts-dna/2.2.0/SEQC-II/202604018825f20d/L2300943__L2300950/,L2300943,L2300950

--- a/docs/testing-validation.md
+++ b/docs/testing-validation.md
@@ -50,7 +50,10 @@ The OA-only path expects the oncoanalyser v2.2.0 layout: `esvee/`,
 ## Hypermutated edge case (>450k variants)
 
 The PCGR-skip / VCF2MAF-skip logic (sash #59, tracked by #52) needs a genuinely hypermutated
-sample.
+sample. This is a bolt/PCGR problem, not sash-only: the failure it guards against is an OOM
+inside PCGR (which runs in bolt), recorded for SBJ02862 in
+[umccr/biodaily#199](https://github.com/umccr/biodaily/issues/199). bolt #33/#36 carry the
+matching fixes.
 
 - **Smoke test:** a synthetic 550k-variant VCF exercises the skip branch directly and confirms
   the sample exits 0 without a full run. Generate one with a script that emits >450k PASS
@@ -65,6 +68,11 @@ Compare a new release against the previous one with the Sash Regression Service
 ([`umccr/service-sash-regression`](https://github.com/umccr/service-sash-regression)) on case
 SEQC-II-medium (L2301218/L2301217). The 0.6.4 baseline is already wired. This replaces manual
 output diffing.
+
+The prior 0.7.0-vs-0.6.x validation record — 11 samples, CPSR/PCGR concordance, tier analysis,
+and the validated sash+bolt version table — is
+[umccr/biodaily#199](https://github.com/umccr/biodaily/issues/199). Use it as the concordance
+baseline rather than re-running those comparisons.
 
 ## Variant monitoring (NATA)
 

--- a/docs/testing-validation.md
+++ b/docs/testing-validation.md
@@ -1,0 +1,79 @@
+# Testing and validation
+
+How to validate a sash change against real cloud data before merge. Covers the standard
+DRAGEN+OA path, the OA-only path, the hypermutated edge case, and release regression.
+
+Ready-to-run samplesheets live in [`assets/test/`](../assets/test). All input S3 paths were
+verified readable on 2026-07-22 via `umccr-prod-operator` / `umccr-development-ro`.
+
+## Test samples
+
+| Sample | Mode | Samplesheet | Purpose |
+|--------|------|-------------|---------|
+| SEQC-II — SBJ00480 (L2300943/L2300950, HCC1395) | DRAGEN+OA | `assets/test/samplesheet_dragen_oa_seqcii.csv` | full-pipeline regression |
+| SEQC-II — SBJ00480 | OA-only | `assets/test/samplesheet_oa_only_seqcii.csv` | OA-only clean reference |
+| L2600284/L2600285 (real prod, OA v2.2.0) | OA-only | `assets/test/samplesheet_oa_only_l2600284.csv` | OA-only real-data e2e |
+| Synthetic 550k-variant VCF | PCGR-skip | generated (see below) | >450k skip smoke test |
+
+SEQC-II is the primary regression sample. Its full package is staged in the read-only
+testdata bucket:
+
+```
+s3://test-data-503977275616-ap-southeast-2/testdata/analysis/production/
+  dragen-wgts-dna/4.4.6/SEQC-II/20260330a606412c/      # DRAGEN somatic + germline
+  oncoanalyser-wgts-dna/2.2.0/SEQC-II/20260401d6eff920/ # OA output
+  sash/0.6.4/SEQC-II/20260428471bb6ed/                  # baseline for concordance
+```
+
+## Run a validation
+
+1. Build a disposable bolt image off the bolt PR branch (`v<version>-<repo><issue>`, e.g.
+   `v0.3.2-sash59`). Wait for all image variants before continuing.
+2. Check out the sash branch and point its `container` refs in `modules/local/bolt/` at the
+   eval tag.
+3. Run with `nextflow-stack`'s `run.sh` and `nextflow_aws.template.config`, passing one of the
+   samplesheets above as `--input`. Pin Nextflow to the version in the workflow config and use
+   AWS CLI v2.
+
+OA-only mode reads `tumor_id` and `normal_id` from the samplesheet directly and accepts only
+`oncoanalyser_dir` rows — `run.sh` still expects DRAGEN args, so pass a hand-written samplesheet
+to `nextflow run` rather than using its samplesheet generation.
+
+## Choosing an OA-only sample
+
+The OA-only path expects the oncoanalyser v2.2.0 layout: `esvee/`,
+`sage_calling/somatic/{tumor_id}.sage.somatic.vcf.gz`, and `pave/{tumor_id}.pave.germline.vcf.gz`
+(tumor-id prefix). Older OA outputs use `gridss`/`gripss`, `sage/`, and germline PAVE named
+`*.sage.germline.pave.vcf.gz` — `prepare_input.nf` cannot detect these. Confirm `esvee/` and
+`pave/{tumor}.pave.germline.vcf.gz` exist before picking a sample, or re-run OA at v2.2.0.
+
+## Hypermutated edge case (>450k variants)
+
+The PCGR-skip / VCF2MAF-skip logic (sash #59, tracked by #52) needs a genuinely hypermutated
+sample.
+
+- **Smoke test:** a synthetic 550k-variant VCF exercises the skip branch directly and confirms
+  the sample exits 0 without a full run. Generate one with a script that emits >450k PASS
+  records, then feed it to bolt's PCGR prep.
+- **Real-data sign-off:** the known real hypermutators (L2100242, 595k PASS; SBJ02862 /
+  L2201449, the OOM case) roll off the prod cache over time. Re-stage one from the portal
+  (`api/v1/s3/attributes?portalRunId=…`); a DRAGEN+OA re-run may be needed before sash.
+
+## Release regression
+
+Compare a new release against the previous one with the Sash Regression Service
+([`umccr/service-sash-regression`](https://github.com/umccr/service-sash-regression)) on case
+SEQC-II-medium (L2301218/L2301217). The 0.6.4 baseline is already wired. This replaces manual
+output diffing.
+
+## Variant monitoring (NATA)
+
+Germline variant-drift monitoring on GIAB control libraries has its own SOPs in
+[`umccr/accreditation`](https://github.com/umccr/accreditation/tree/main/wgs-variant-monitoring-workflow/docs)
+(`RUNBOOK.md`, `SOP_OUTLIER_REVIEW.md`, `SOP_OUT_OF_LIMITS_REVIEW.md`).
+
+## Sign-off criteria
+
+- somatic PASS concordance ≥ 81.2% vs the 0.6.4 baseline
+- PURPLE purity and ploidy identical to baseline
+- all three cancer reports render without error


### PR DESCRIPTION
Ports the essentials of the EC2 validation runbook into the repo so the team can reach them — no more validation knowledge trapped in a personal Obsidian vault.

Adds:
- `docs/testing-validation.md` — how to validate a sash change against real cloud data (standard DRAGEN+OA, OA-only, hypermutated edge case, release regression, NATA link)
- `assets/test/` — three ready-to-run samplesheets holding team-accessible S3 paths: SEQC-II DRAGEN+OA, SEQC-II OA-only, and L2600284 OA-only
- `.github/ISSUE_TEMPLATE/release-validation.md` — reusable pre-merge checklist

All input S3 paths verified readable 2026-07-22.

Two findings baked into the docs:
- **OA-only needs the oncoanalyser v2.2.0 layout** (`esvee/`, `pave/{tumor}.pave.germline.vcf.gz`). Older outputs (e.g. SBJ04890, 2025-06) use `gridss`/`gripss` + `*.sage.germline.pave.vcf.gz` and are not drop-in — hence L2600284 as the real-data OA-only sample.
- **Real hypermutators roll off the prod cache.** L2100242 and SBJ02862 are gone from S3; the >450k skip test (#52 / #59) smoke-tests on a synthetic 550k VCF now, and real-data sign-off needs re-staging.
