### PR TITLE
fix: correct bolt version to 0.3.1 in sash 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,14 +38,13 @@ Initial release of umccr/sash, created with the [nf-core](https://nf-co.re/) tem
 
 ### Fixed
 
-- Bump bolt to 0.3.2: PCGR now gracefully skips hypermutated samples whose variant count still exceeds the per-chunk ceiling ([sash#52](https://github.com/umccr/sash/issues/52)), and PCGR chunk runs disable MSI/TMB estimates that were meaningless on partial VCFs
 - Migrate sigrap containers from personal `docker.io/qclayssen/sigrap:0.3.0-dev-8` build to official `ghcr.io/umccr/sigrap:0.3.0`
 
 ### Dependencies
 
 | Tool      | Old      | New      |
 | --------- | -------- | -------- |
-| bolt      | 0.2.17   | 0.3.2    |
+| bolt      | 0.2.17   | 0.3.1    |
 | sigrap    | —        | 0.3.0    |
 | PCGR      | —        | v2.2.5   |
 | PCGR data | 20220203 | 20250314 |

--- a/modules/local/bolt/other/cancer_report/main.nf
+++ b/modules/local/bolt/other/cancer_report/main.nf
@@ -3,7 +3,7 @@ process BOLT_OTHER_CANCER_REPORT {
     label 'process_medium_memory'
     label 'process_long'
 
-    container 'ghcr.io/umccr/bolt:0.3.2-gpgr'
+    container 'ghcr.io/umccr/bolt:0.3.1-gpgr'
 
     input:
     tuple val(meta), path(smlv_somatic_vcf), path(smlv_somatic_bcftools_stats), path(smlv_somatic_counts_process), path(sv_somatic_tsv), path(sv_somatic_vcf), path(cnv_somatic_tsv), path(af_global), path(af_keygenes), path(purple_baf_plot), path(purple_dir), path(virusbreakend_dir), path(dragen_hrd), path(smlv_somatic_mutpat), path(smlv_somatic_hrdetect), path(smlv_somatic_chord)

--- a/modules/local/bolt/other/multiqc_report/main.nf
+++ b/modules/local/bolt/other/multiqc_report/main.nf
@@ -2,7 +2,7 @@ process BOLT_OTHER_MULTIQC_REPORT {
     tag "${meta.id}"
     label 'process_low'
 
-    container 'ghcr.io/umccr/bolt:0.3.2-multiqc'
+    container 'ghcr.io/umccr/bolt:0.3.1-multiqc'
 
     input:
     tuple val(meta), path(input_files)

--- a/modules/local/bolt/other/purple_baf_plot/main.nf
+++ b/modules/local/bolt/other/purple_baf_plot/main.nf
@@ -2,7 +2,7 @@ process BOLT_OTHER_PURPLE_BAF_PLOT {
     tag "${meta.id}"
     label 'process_low'
 
-    container 'ghcr.io/umccr/bolt:0.3.2-circos'
+    container 'ghcr.io/umccr/bolt:0.3.1-circos'
 
     input:
     tuple val(meta), path(purple_dir)

--- a/modules/local/bolt/smlv_germline/prepare/main.nf
+++ b/modules/local/bolt/smlv_germline/prepare/main.nf
@@ -2,7 +2,7 @@ process BOLT_SMLV_GERMLINE_PREPARE {
     tag "${meta.id}"
     label 'process_low'
 
-    container 'ghcr.io/umccr/bolt:0.3.2'
+    container 'ghcr.io/umccr/bolt:0.3.1'
 
     input:
     tuple val(meta), path(smlv_vcf)

--- a/modules/local/bolt/smlv_germline/report/main.nf
+++ b/modules/local/bolt/smlv_germline/report/main.nf
@@ -2,7 +2,7 @@ process BOLT_SMLV_GERMLINE_REPORT {
     tag "${meta.id}"
     label 'process_low'
 
-    container 'ghcr.io/umccr/bolt:0.3.2-pcgr'
+    container 'ghcr.io/umccr/bolt:0.3.1-pcgr'
 
     input:
     tuple val(meta), path(smlv_vcf), path(smlv_unfiltered_vcf)

--- a/modules/local/bolt/smlv_somatic/annotate/main.nf
+++ b/modules/local/bolt/smlv_somatic/annotate/main.nf
@@ -3,7 +3,7 @@ process BOLT_SMLV_SOMATIC_ANNOTATE {
     label 'process_medium_memory'
     label 'process_long'
 
-    container 'ghcr.io/umccr/bolt:0.3.2-pcgr'
+    container 'ghcr.io/umccr/bolt:0.3.1-pcgr'
 
     input:
     tuple val(meta), path(smlv_vcf)

--- a/modules/local/bolt/smlv_somatic/filter/main.nf
+++ b/modules/local/bolt/smlv_somatic/filter/main.nf
@@ -2,7 +2,7 @@ process BOLT_SMLV_SOMATIC_FILTER {
     tag "${meta.id}"
     label 'process_low'
 
-    container 'ghcr.io/umccr/bolt:0.3.2'
+    container 'ghcr.io/umccr/bolt:0.3.1'
 
     input:
     tuple val(meta), path(smlv_vcf)

--- a/modules/local/bolt/smlv_somatic/report/main.nf
+++ b/modules/local/bolt/smlv_somatic/report/main.nf
@@ -2,7 +2,7 @@ process BOLT_SMLV_SOMATIC_REPORT {
     tag "${meta.id}"
     label 'process_low'
 
-    container 'ghcr.io/umccr/bolt:0.3.2-pcgr'
+    container 'ghcr.io/umccr/bolt:0.3.1-pcgr'
 
     input:
     tuple val(meta), path(smlv_vcf), path(smlv_filters_vcf), path(smlv_dragen_vcf), path(purple_purity)

--- a/modules/local/bolt/smlv_somatic/rescue/main.nf
+++ b/modules/local/bolt/smlv_somatic/rescue/main.nf
@@ -2,7 +2,7 @@ process BOLT_SMLV_SOMATIC_RESCUE {
     tag "${meta.id}"
     label 'process_low'
 
-    container 'ghcr.io/umccr/bolt:0.3.2'
+    container 'ghcr.io/umccr/bolt:0.3.1'
 
     input:
     tuple val(meta), path(smlv_vcf), path(smlv_tbi), path(sage_smlv_vcf), path(sage_smlv_tbi)

--- a/modules/local/bolt/sv_somatic/annotate/main.nf
+++ b/modules/local/bolt/sv_somatic/annotate/main.nf
@@ -2,7 +2,7 @@ process BOLT_SV_SOMATIC_ANNOTATE {
     tag "${meta.id}"
     label 'process_low'
 
-    container 'ghcr.io/umccr/bolt:0.3.2-snpeff'
+    container 'ghcr.io/umccr/bolt:0.3.1-snpeff'
 
     input:
     tuple val(meta), path(sv_vcf), path(cnv_tsv)

--- a/modules/local/bolt/sv_somatic/prioritise/main.nf
+++ b/modules/local/bolt/sv_somatic/prioritise/main.nf
@@ -2,7 +2,7 @@ process BOLT_SV_SOMATIC_PRIORITISE {
     tag "${meta.id}"
     label 'process_low'
 
-    container 'ghcr.io/umccr/bolt:0.3.2'
+    container 'ghcr.io/umccr/bolt:0.3.1'
 
     input:
     tuple val(meta), path(sv_vcf)


### PR DESCRIPTION
sash 0.7.0 was validated with bolt 0.3.1 (biodaily #199). The 0.3.2 container refs and changelog entry were incorrectly included from the release/0.7.0 branch which had been developed ahead of the validated state. The bolt 0.3.2 bump belongs in sash 0.7.1 (release/0.7.1).

Changes:
- Revert all 11 bolt container refs from `0.3.2` to `0.3.1`
- Fix CHANGELOG dependencies table (`0.2.17 → 0.3.1`, not `0.3.2`)
- Remove PCGR-skip Fixed entry (belongs in 0.7.1, already present there)

This should merge before sash #60 (Release 0.7.1) so the history is clean: 0.7.0 = bolt 0.3.1, 0.7.1 = bolt 0.3.2.